### PR TITLE
Remove suggestion for global installation of Lerna:

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,19 @@
 
 1. Install NodeJS >= [v6.11.0](http://nodejs.org/dist/v6.11.0/), if you don't have it yet.
 
-2. Install lerna global dependency:
-
-  ```
-  [sudo] npm install -g lerna
-  ```
-
-3. Run the bootstrap script to install local dependencies and link packages together:
+2. Run the bootstrap script to install local dependencies and link packages together:
 
   ```
   npm run lerna
   ```
 
-4. Build all packages
+3. Build all packages
 
   ```
   npm run build
   ```
 
-5. Run tests:
+4. Run tests:
 
   ```
   npm run test


### PR DESCRIPTION
Since `lerna` is one of the `devDependencies` of the project there’s no need to have a globally installed instance too.

All command run through `npm run` will have `lerna` available anyway.