### PR TITLE
Add failing tests on packages that end with '.js'

### DIFF
--- a/packages/babel-plugin-normalize-requires/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/babel-plugin-normalize-requires/src/__tests__/__snapshots__/index.test.js.snap
@@ -15,6 +15,16 @@ exports[`when requiring external modules removes trailing "/" from module names 
 require('a-package/a-module.js');"
 `;
 
+exports[`when requiring local modules keeps trailing ".js" from package names 1`] = `
+"
+require('a-package.js');"
+`;
+
+exports[`when requiring local modules keeps trailing ".js" from package names 2`] = `
+"
+require('@some-scope/a-package.js');"
+`;
+
 exports[`when requiring local modules removes trailing ".js" from module names 1`] = `
 "
 require('./a-module');"

--- a/packages/babel-plugin-normalize-requires/src/__tests__/index.test.js
+++ b/packages/babel-plugin-normalize-requires/src/__tests__/index.test.js
@@ -2,6 +2,30 @@ import * as babel from 'babel-core';
 import plugin from '../index';
 
 describe('when requiring local modules', () => {
+	it('keeps trailing ".js" from package names', () => {
+		const source = `
+	    require('a-package.js')
+	    `;
+
+		const { code } = babel.transform(source, {
+			plugins: [plugin],
+		});
+
+		expect(code).toMatchSnapshot();
+	});
+
+	it('keeps trailing ".js" from package names', () => {
+		const source = `
+	    require('@some-scope/a-package.js')
+	    `;
+
+		const { code } = babel.transform(source, {
+			plugins: [plugin],
+		});
+
+		expect(code).toMatchSnapshot();
+	});
+
 	it('removes trailing ".js" from module names', () => {
 		const source = `
 	    require('./a-module.js')


### PR DESCRIPTION
When normalizing require names a package name must not be touched at all.

While discouraged, packages can still end with `.js` so removing it from the name would break the require call.

Also simply checking for a `/` in the require name is not enough because we need to include scoped packages in the equation, those in the form `@scope-name/package-name[/sub/module]`.