### PR TITLE
Fixes #222 - Updating the version of the copy-webpack-plugin package from 4.0.0 to 4.5.4

### DIFF
--- a/packages/generator-liferay-bundle/src/facet-start/index.js
+++ b/packages/generator-liferay-bundle/src/facet-start/index.js
@@ -31,7 +31,7 @@ export default class extends Generator {
 
 		gitignore.add('.webpack/*');
 
-		pkgJson.addDevDependency('copy-webpack-plugin', '^4.0.0');
+		pkgJson.addDevDependency('copy-webpack-plugin', '^4.5.4');
 		pkgJson.addDevDependency('webpack', '^4.0.0');
 		pkgJson.addDevDependency('webpack-cli', '^3.0.0');
 		pkgJson.addDevDependency('webpack-dev-server', '^3.0.0');


### PR DESCRIPTION
It seems that they introduced support for webpack 4 from version 4.4.x, so it caused this error. And it seems to happen only on some machines.

Let me know if I'm modifying in the right place.